### PR TITLE
Fix Amazon question count

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ fastprep sync --season 2026
 ```text
 top tracked companies ──────────── snapshot · Jul 2026 ──
 
-Amazon       ██████████████████████ 369
+Amazon       ██████████████████████ 370
 Google       ██████ 99
 IBM          █████ 83
 TikTok       ████ 74


### PR DESCRIPTION
## Summary

Follow-up to #131. The July 31 update added one Amazon coding question, so the visible Amazon coverage snapshot increments from 369 to 370, matching the Microsoft and Snowflake count updates in the merged change.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/test_sync_practice_formats.py` — 10 tests passed.
- `python3 scripts/sync-practice-formats.py --sync-date 2026-08-01 --check` — passed; Coding=1,665, unclassified=0.
- `git diff --check` — passed.
- Full resulting-state audit — all 21 added algorithm rows match the live public catalog, appear exactly once in README and the Coding projection, remain globally date-sorted, and return HTTP 200.
- Scope is one README count line.

## Independent review

- Result: no findings.
- Reviewed head: `a52042ff9b6ccf3f66051a8a940057d698635823`
- Reviewed target: `b5da6e4bc9661b32f9af36bde3767c5cbe991edd`
- Scope: complete PR diff plus the resulting state of all 21 rows, metadata, route occurrence semantics, sorting, Coding count/projection, company snapshot, production links, and focused checks.
- GitHub state at review: open draft, cleanly mergeable.
- Remaining risks: GitHub attached no automated checks, so verification evidence is local. The top-company snapshot is hand-maintained; this review validates the intended +1 delta rather than reconstructing every historical total.