### PR TITLE
[FastPrep] Refresh Millennium OA questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Share questions through the [OA template](https://github.com/perixtar/2026-Tech-
 <sub>Newest updates first &nbsp;·&nbsp; 🔥 added in the last 2 weeks &nbsp;·&nbsp; 🆕 in the last 45 days</sub>
 
 <!-- format-links:start -->
-<sub><b>Formats:</b> [Coding (1,808)](formats/coding.md) · [SQL (20)](formats/sql.md) · [System design (274)](formats/system-design.md) · [Low-level design (61)](formats/low-level-design.md) · [AI coding (31)](formats/ai-coding.md)</sub>
+<sub><b>Formats:</b> [Coding (1,808)](formats/coding.md) · [SQL (23)](formats/sql.md) · [System design (274)](formats/system-design.md) · [Low-level design (61)](formats/low-level-design.md) · [AI coding (31)](formats/ai-coding.md)</sub>
 <!-- format-links:end -->
 
 <sub><b>Updated</b>: latest sighting, else first public sync; <b>Unattributed</b>: no source-backed employer.</sub>
@@ -44,6 +44,19 @@ Share questions through the [OA template](https://github.com/perixtar/2026-Tech-
 | **Two Sigma** |[Online No-Intercept Linear Regression](https://www.fastprep.io/problems/two-sigma-online-no-intercept-linear-regression)| Coding |[![Practice][p]](https://www.fastprep.io/problems/two-sigma-online-no-intercept-linear-regression)| 🔥 Sep 09, 2026 |
 | **Two Sigma** |[Linear Interpolator](https://www.fastprep.io/problems/two-sigma-linear-interpolator)| Coding |[![Practice][p]](https://www.fastprep.io/problems/two-sigma-linear-interpolator)| 🔥 Sep 09, 2026 |
 | **Two Sigma** |[Daily Temperature By Town](https://www.fastprep.io/problems/two-sigma-daily-temperature-by-town)| SQL |[![Practice][p]](https://www.fastprep.io/problems/two-sigma-daily-temperature-by-town)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Debug the Tape Cleaner](https://www.fastprep.io/problems/millennium-debug-tape-cleaner)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-debug-tape-cleaner)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Regression Hedge](https://www.fastprep.io/problems/millennium-regression-hedge)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-regression-hedge)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Client Markout Analysis](https://www.fastprep.io/problems/millennium-client-markout-analysis)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-client-markout-analysis)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Clean the Tape](https://www.fastprep.io/problems/millennium-clean-the-tape)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-clean-the-tape)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Measure Liquidity](https://www.fastprep.io/problems/millennium-measure-liquidity)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-measure-liquidity)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Debug Fair-Value Lookup](https://www.fastprep.io/problems/millennium-debug-fair-value-lookup)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-debug-fair-value-lookup)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Calculate the Half Spread](https://www.fastprep.io/problems/millennium-calculate-half-spread)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-calculate-half-spread)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Quote One Request](https://www.fastprep.io/problems/millennium-quote-one-request)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-quote-one-request)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Debug the Impact Model](https://www.fastprep.io/problems/millennium-debug-impact-model)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-debug-impact-model)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Track the Book and Mark Final PnL](https://www.fastprep.io/problems/millennium-track-the-book)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-track-the-book)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Risk Limits and Inventory Skew](https://www.fastprep.io/problems/millennium-risk-limits-and-skew)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-risk-limits-and-skew)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Debug the Risk-Limit Quoter](https://www.fastprep.io/problems/millennium-debug-risk-limit-quoter)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-debug-risk-limit-quoter)| 🔥 Sep 09, 2026 |
+| **Millennium** |[Hedge Inventory with Return Covariance](https://www.fastprep.io/problems/millennium-hedge-inventory)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-hedge-inventory)| 🔥 Sep 09, 2026 |
 | **Stripe** |[Asynchronous Payment Event Processing](https://www.fastprep.io/problems/stripe-asynchronous-payment-event-processing)| Coding |[![Practice][p]](https://www.fastprep.io/problems/stripe-asynchronous-payment-event-processing)| 🔥 Sep 08, 2026 |
 | **Stripe** |[Financial Account Ledger](https://www.fastprep.io/problems/stripe-financial-account-ledger)| Coding |[![Practice][p]](https://www.fastprep.io/problems/stripe-financial-account-ledger)| 🔥 Sep 08, 2026 |
 | **Capital One** |[Count Good Tuples](https://www.fastprep.io/problems/capital-one-count-good-tuples)| Coding |[![Practice][p]](https://www.fastprep.io/problems/capital-one-count-good-tuples)| 🔥 Sep 08, 2026 |
@@ -85,16 +98,6 @@ Share questions through the [OA template](https://github.com/perixtar/2026-Tech-
 | **Amazon** |[Design and Implement a Train Route Fare Calculator](https://www.fastprep.io/low-level-design/train-route-fare-calculator)| Low-level design |[![Practice][p]](https://www.fastprep.io/low-level-design/train-route-fare-calculator)| 🔥 Sep 03, 2026 |
 | **Amazon** |[Design a Return Drop-Store Booking System](https://www.fastprep.io/low-level-design/return-drop-store-booking)| Low-level design |[![Practice][p]](https://www.fastprep.io/low-level-design/return-drop-store-booking)| 🔥 Sep 03, 2026 |
 | **Roblox** |[Rate Limiter Sliding Window With Per-Entity Limits](https://www.fastprep.io/problems/roblox-rate-limiter-sliding-window-per-entity)| Coding |[![Practice][p]](https://www.fastprep.io/problems/roblox-rate-limiter-sliding-window-per-entity)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Clean the Tape](https://www.fastprep.io/problems/millennium-clean-the-tape)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-clean-the-tape)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Measure Liquidity](https://www.fastprep.io/problems/millennium-measure-liquidity)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-measure-liquidity)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Debug Fair-Value Lookup](https://www.fastprep.io/problems/millennium-debug-fair-value-lookup)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-debug-fair-value-lookup)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Calculate the Half Spread](https://www.fastprep.io/problems/millennium-calculate-half-spread)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-calculate-half-spread)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Quote One Request](https://www.fastprep.io/problems/millennium-quote-one-request)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-quote-one-request)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Debug the Impact Model](https://www.fastprep.io/problems/millennium-debug-impact-model)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-debug-impact-model)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Track the Book and Mark Final PnL](https://www.fastprep.io/problems/millennium-track-the-book)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-track-the-book)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Risk Limits and Inventory Skew](https://www.fastprep.io/problems/millennium-risk-limits-and-skew)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-risk-limits-and-skew)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Debug the Risk-Limit Quoter](https://www.fastprep.io/problems/millennium-debug-risk-limit-quoter)| Coding |[![Practice][p]](https://www.fastprep.io/problems/millennium-debug-risk-limit-quoter)| 🔥 Sep 02, 2026 |
-| **Millennium** |[Hedge Inventory with Return Covariance](https://www.fastprep.io/problems/millennium-hedge-inventory)| SQL |[![Practice][p]](https://www.fastprep.io/problems/millennium-hedge-inventory)| 🔥 Sep 02, 2026 |
 | **OpenAI / The D. E. Shaw Group / Zoox / Salesforce** |[Design an Online Payment Processing System](https://www.fastprep.io/system-design/online-payment-processing-system)| System design |[![Practice][p]](https://www.fastprep.io/system-design/online-payment-processing-system)| 🔥 Sep 02, 2026 |
 | **DoorDash** |[Build a Dasher Payout Service](https://www.fastprep.io/project-coding/doordash-dasher-payout-service)| AI coding |[![Practice][p]](https://www.fastprep.io/project-coding/doordash-dasher-payout-service)| 🔥 Sep 02, 2026 |
 | **Amazon** |[Repair Blog Post Creation](https://www.fastprep.io/project-coding/amazon-django-blog-post-creation)| AI coding |[![Practice][p]](https://www.fastprep.io/project-coding/amazon-django-blog-post-creation)| 🔥 Sep 02, 2026 |


### PR DESCRIPTION
## Summary

- add three newly published Millennium SQL practice problems
- refresh ten existing Millennium rows to the September 9, 2026 sighting
- preserve the public FastPrep format for every route
- update the README format summary from SQL 20 to SQL 23
- preserve the Two Sigma changes already merged through PR #170 while rebasing this PR onto current `master`

## Verification

- all 13 FastPrep APIs and canonical pages returned HTTP 200 and matched the exact public catalog projection
- the final README has 2,197 rows and 2,197 unique routes; every row has six pipes, matching practice links, and descending dates
- the 13 intended Millennium changes are exactly 3 additions and 10 date-only refreshes; no other existing row changed
- format counts are Coding 1,808; SQL 23; System design 274; Low-level design 61; AI coding 31
- the company list has 267 unique, case-insensitively ordered entries
- `python3 scripts/refresh-freshness.py` made zero marker changes and zero row moves; README is 499,933 bytes
- `python3 -m unittest scripts/test_sync_practice_formats.py` passed 11/11
- split GitHub-flavored Markdown rendering, `git diff --check`, and privacy/credential scans passed

`python3 scripts/sync-practice-formats.py --check` retains inherited repository-wide debt on both base and head: the live-catalog projection exceeds the 500,000-byte limit and reports the same 72 catalog-missing legacy routes. The committed README itself passes the size and freshness guards with 67 bytes of headroom.

## Independent regression review

A separate reviewer audited exact head `623937a05059ebdf9ee683a6738601b1ef2ad34f` against current master `b1828221736e1b417547162acf1f7da32520556d`. The review covered the complete README diff, every base-row semantic field, route ownership and ordering, format/company totals, public API/page identity, freshness, GFM rendering, size, privacy, and failure paths. It found no P0-P3 issue.

This PR is the oldest open `master` PR. It was marked ready externally before this conflict repair; this update does not merge it or change its ready state.
